### PR TITLE
Resolving swarm-manager-1 connect issue

### DIFF
--- a/terraform/aws/swarm.tf
+++ b/terraform/aws/swarm.tf
@@ -2,6 +2,9 @@ resource "aws_instance" "swarm-manager" {
     count = "${var.swarm_managers}"
     ami = "${var.swarm_ami_id}"
     instance_type = "${var.swarm_instance_type}"
+
+    # Added to force IG creation when running just swarm-init
+    depends_on = ["module.vpc-IG"]
     
     # VPC subnet
     # Spread instances across the subnets


### PR DESCRIPTION
swarm.tf - since we were only building a portion of the environment using '-target', we were not triggering the build of the Internet Gateway, therefore the server was not internet accessible.  I fixed by forcing a dependency of swarm-manager-1 on the IG.